### PR TITLE
Resolves an issue blocking finds

### DIFF
--- a/source/Spiral/ODM/Entities/Compositor.php
+++ b/source/Spiral/ODM/Entities/Compositor.php
@@ -819,7 +819,7 @@ class Compositor extends Component implements
         }
 
         //Trying to create using ODM
-        return $this->documents[$offset] = $this->odm->document($this->class, $document, $this);
+        return $this->documents[$offset] = $this->odm->document($this->class, (array)$document, $this);
     }
 
     /**


### PR DESCRIPTION
The below errors are thrown when performing a find on the ODM

`ErrorException: Argument 2 passed to Spiral\ODM\ODM::document() must be of the type array, string given, called in .../vendor/spiral/components/source/Spiral/ODM/Entities/Compositor.php on line 825 and defined in .../vendor/spiral/components/source/Spiral/ODM/ODM.php at line 210`

`ErrorException: ReflectionProperty::getValue(): The 'connected' property is deprecated in .../vendor/spiral/components/source/Spiral/Debug/Dumper.php at line 332`

$document seemed to be set to value `Rerum."`

Type casting to array seems to resolve the issue, and allows the query to proceed
